### PR TITLE
Fix WhereClause::whereExists() and WhereClause::whereNotExists() PHPDoc

### DIFF
--- a/src/DB/QueryBuilder/Concerns/WhereClause.php
+++ b/src/DB/QueryBuilder/Concerns/WhereClause.php
@@ -337,7 +337,7 @@ trait WhereClause {
 	/**
 	 * @param  Closure  $callback  The closure will receive a StellarWP\DB\QueryBuilder\QueryBuilder instance
 	 *
-	 * @return QueryBuilder|WhereQueryBuilder
+	 * @return $this
 	 */
 	public function whereExists( $callback ) {
 		return $this->where(
@@ -350,7 +350,7 @@ trait WhereClause {
 	/**
 	 * @param  Closure  $callback  The closure will receive a StellarWP\DB\QueryBuilder\QueryBuilder instance
 	 *
-	 * @return QueryBuilder|WhereQueryBuilder
+	 * @return $this
 	 */
 	public function whereNotExists( $callback ) {
 		return $this->where(


### PR DESCRIPTION
PHPStan throws `Call to an undefined method ::limit()` when you do something like this. I checked and all builder methods there return `$this`, so I just did the same for these 2 methods.

```
DB::table( 'posts' )
    ->select( 'ID' )
    ->whereNotExists(
        function ( QueryBuilder $builder ) {
            // whatever.
        }
    )
    ->limit( 1 );
```

