### PR TITLE
Fix array shape for errors in DatabaseQueryException

### DIFF
--- a/src/DB/Database/Exceptions/DatabaseQueryException.php
+++ b/src/DB/Database/Exceptions/DatabaseQueryException.php
@@ -14,7 +14,7 @@ use Throwable;
  */
 class DatabaseQueryException extends \Exception {
 	/**
-	 * @var string[]
+	 * @var array<string, string[]>
 	 */
 	private $queryErrors;
 
@@ -25,6 +25,8 @@ class DatabaseQueryException extends \Exception {
 
 	/**
 	 * @since 1.0.0
+	 *
+	 * @param array<string, string[]> $queryErrors
 	 */
 	public function __construct(
 		string $query,
@@ -44,7 +46,7 @@ class DatabaseQueryException extends \Exception {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return string[]
+	 * @return array<string, string[]>
 	 */
 	public function getQueryErrors(): array {
 		return $this->queryErrors;


### PR DESCRIPTION
Fixes the incorrect array shape for the collected Query Errors in DatabaseQueryException.

Errors look like:

```
object(StellarWP\Licensing\StellarWP\DB\Database\Exceptions\DatabaseQueryException)#1217 (9) {
  ["queryErrors":"StellarWP\Licensing\StellarWP\DB\Database\Exceptions\DatabaseQueryException":private]=>
  array(1) {
    ["db_delta_error"]=>
    array(1) {
      [0]=>
      string(59) "Duplicate entry 'test.com-1-5' for key 'domain_user_origin'"
    }
  }
```

