### PR TITLE
Don't `trim( null )`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. This project adhere to the [Semantic Versioning](http://semver.org/) standard.
 
+## [1.0.4] 2023-10-23
+
+* Tweak - Updates around `trim()` for php 8.1 compatibility.
+* Tweak - Force From() and Select() to convert passed non-strings to an empty string.
+* Tweak - Convert all function signatures that take `$alias` as a param to use only `string` instead of `string|null`.
+
 ## [1.0.3] 2022-11-22
 
 * Tweak - Set composer.json `config.platform.php` to `7.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,23 @@
 
 All notable changes to this project will be documented in this file. This project adhere to the [Semantic Versioning](http://semver.org/) standard.
 
-## [1.0.4] 2023-10-23
+## [1.0.7] 2023-10-23
 
 * Tweak - Updates around `trim()` for php 8.1 compatibility.
-* Tweak - Force From() and Select() to convert passed non-strings to an empty string.
-* Tweak - Convert all function signatures that take `$alias` as a param to use only `string` instead of `string|null`.
+* Tweak - Force `From()` and `Select()` to convert passed non-strings to an empty string.
+
+## [1.0.6] 2023-09-05
+
+* Tweak - Fix array shape for errors in `DatabaseQueryException`
+
+## [1.0.5] 2023-09-05
+
+* Tweak - Updating docblock for `whereExists()` and `whereNotExists()` in response to a PHPStan flag.
+
+## [1.0.4] 2023-06-06
+
+* Tweak - Added more documentation for methods provided by DB.
+* Tweak - Adjusted docblocks to better declare types.
 
 ## [1.0.3] 2022-11-22
 

--- a/src/DB/DB.php
+++ b/src/DB/DB.php
@@ -173,11 +173,11 @@ class DB {
 	 * Create QueryBuilder instance
 	 *
 	 * @param string|RawSQL $table
-	 * @param null|string $alias
+	 * @param string $alias
 	 *
 	 * @return QueryBuilder
 	 */
-	public static function table( $table, $alias = null ) {
+	public static function table( $table, $alias = '' ) {
 		$builder = new QueryBuilder();
 		$builder->from( $table, $alias );
 

--- a/src/DB/DB.php
+++ b/src/DB/DB.php
@@ -173,7 +173,7 @@ class DB {
 	 * Create QueryBuilder instance
 	 *
 	 * @param string|RawSQL $table
-	 * @param string $alias
+	 * @param null|string  $alias
 	 *
 	 * @return QueryBuilder
 	 */

--- a/src/DB/DB.php
+++ b/src/DB/DB.php
@@ -173,7 +173,7 @@ class DB {
 	 * Create QueryBuilder instance
 	 *
 	 * @param string|RawSQL $table
-	 * @param null|string  $alias
+	 * @param string|null  $alias
 	 *
 	 * @return QueryBuilder
 	 */

--- a/src/DB/QueryBuilder/Clauses/From.php
+++ b/src/DB/QueryBuilder/Clauses/From.php
@@ -24,6 +24,6 @@ class From {
 	 */
 	public function __construct( $table, $alias = null ) {
 		$this->table = QueryBuilder::prefixTable( $table );
-		$this->alias = trim( $alias );
+		$this->alias = is_null( $alias ) ? null : trim( $alias );
 	}
 }

--- a/src/DB/QueryBuilder/Clauses/From.php
+++ b/src/DB/QueryBuilder/Clauses/From.php
@@ -20,7 +20,7 @@ class From {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  string  $alias
+	 * @param  null|string  $alias
 	 */
 	public function __construct( $table, $alias = '' ) {
 		$this->table = QueryBuilder::prefixTable( $table );

--- a/src/DB/QueryBuilder/Clauses/From.php
+++ b/src/DB/QueryBuilder/Clauses/From.php
@@ -20,10 +20,10 @@ class From {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  string|null  $alias
+	 * @param  string  $alias
 	 */
-	public function __construct( $table, $alias = null ) {
+	public function __construct( $table, $alias = '' ) {
 		$this->table = QueryBuilder::prefixTable( $table );
-		$this->alias = is_null( $alias ) ? null : trim( $alias );
+		$this->alias = is_scalar( $alias ) ? trim( (string) $alias ) : '';
 	}
 }

--- a/src/DB/QueryBuilder/Clauses/From.php
+++ b/src/DB/QueryBuilder/Clauses/From.php
@@ -20,7 +20,7 @@ class From {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  null|string  $alias
+	 * @param  string|null  $alias
 	 */
 	public function __construct( $table, $alias = '' ) {
 		$this->table = QueryBuilder::prefixTable( $table );

--- a/src/DB/QueryBuilder/Clauses/Join.php
+++ b/src/DB/QueryBuilder/Clauses/Join.php
@@ -33,7 +33,7 @@ class Join {
 	public function __construct( $joinType, $table, $alias = null ) {
 		$this->table	= QueryBuilder::prefixTable( $table );
 		$this->joinType = $this->getJoinType( $joinType );
-		$this->alias	= trim( $alias );
+		$this->alias	= is_null( $alias ) ? null : trim( $alias );
 	}
 
 	/**

--- a/src/DB/QueryBuilder/Clauses/Join.php
+++ b/src/DB/QueryBuilder/Clauses/Join.php
@@ -28,7 +28,7 @@ class Join {
 	/**
 	 * @param  string  $table
 	 * @param  string  $joinType  \StellarWP\DB\QueryBuilder\Types\JoinType
-	 * @param  string  $alias
+	 * @param  null|string  $alias
 	 */
 	public function __construct( $joinType, $table, $alias = '' ) {
 		$this->table	= QueryBuilder::prefixTable( $table );

--- a/src/DB/QueryBuilder/Clauses/Join.php
+++ b/src/DB/QueryBuilder/Clauses/Join.php
@@ -28,12 +28,12 @@ class Join {
 	/**
 	 * @param  string  $table
 	 * @param  string  $joinType  \StellarWP\DB\QueryBuilder\Types\JoinType
-	 * @param  string|null  $alias
+	 * @param  string  $alias
 	 */
-	public function __construct( $joinType, $table, $alias = null ) {
+	public function __construct( $joinType, $table, $alias = '' ) {
 		$this->table	= QueryBuilder::prefixTable( $table );
 		$this->joinType = $this->getJoinType( $joinType );
-		$this->alias	= is_null( $alias ) ? null : trim( $alias );
+		$this->alias	= is_scalar( $alias ) ? trim( (string) $alias ) : '';
 	}
 
 	/**

--- a/src/DB/QueryBuilder/Clauses/Join.php
+++ b/src/DB/QueryBuilder/Clauses/Join.php
@@ -28,7 +28,7 @@ class Join {
 	/**
 	 * @param  string  $table
 	 * @param  string  $joinType  \StellarWP\DB\QueryBuilder\Types\JoinType
-	 * @param  null|string  $alias
+	 * @param  string|null  $alias
 	 */
 	public function __construct( $joinType, $table, $alias = '' ) {
 		$this->table	= QueryBuilder::prefixTable( $table );

--- a/src/DB/QueryBuilder/Clauses/Select.php
+++ b/src/DB/QueryBuilder/Clauses/Select.php
@@ -18,7 +18,7 @@ class Select {
 
 	/**
 	 * @param  string  $column
-	 * @param  null|string  $alias
+	 * @param  string|null  $alias
 	 */
 	public function __construct( $column, $alias = '' ) {
 		$this->column = trim( $column );

--- a/src/DB/QueryBuilder/Clauses/Select.php
+++ b/src/DB/QueryBuilder/Clauses/Select.php
@@ -22,6 +22,6 @@ class Select {
 	 */
 	public function __construct( $column, $alias = null ) {
 		$this->column = trim( $column );
-		$this->alias  = trim( $alias );
+		$this->alias  = is_null( $alias ) ? null : trim( $alias );
 	}
 }

--- a/src/DB/QueryBuilder/Clauses/Select.php
+++ b/src/DB/QueryBuilder/Clauses/Select.php
@@ -18,7 +18,7 @@ class Select {
 
 	/**
 	 * @param  string  $column
-	 * @param  string  $alias
+	 * @param  null|string  $alias
 	 */
 	public function __construct( $column, $alias = '' ) {
 		$this->column = trim( $column );

--- a/src/DB/QueryBuilder/Clauses/Select.php
+++ b/src/DB/QueryBuilder/Clauses/Select.php
@@ -18,10 +18,10 @@ class Select {
 
 	/**
 	 * @param  string  $column
-	 * @param  string|null  $alias
+	 * @param  string  $alias
 	 */
-	public function __construct( $column, $alias = null ) {
+	public function __construct( $column, $alias = '' ) {
 		$this->column = trim( $column );
-		$this->alias  = is_null( $alias ) ? null : trim( $alias );
+		$this->alias  = is_scalar( $alias ) ? trim( (string) $alias ) : '';
 	}
 }

--- a/src/DB/QueryBuilder/Concerns/FromClause.php
+++ b/src/DB/QueryBuilder/Concerns/FromClause.php
@@ -17,7 +17,7 @@ trait FromClause {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  null|string  $alias
+	 * @param  string|null  $alias
 	 *
 	 * @return $this
 	 */

--- a/src/DB/QueryBuilder/Concerns/FromClause.php
+++ b/src/DB/QueryBuilder/Concerns/FromClause.php
@@ -17,11 +17,11 @@ trait FromClause {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  string|null  $alias
+	 * @param  string  $alias
 	 *
 	 * @return $this
 	 */
-	public function from( $table, $alias = null ) {
+	public function from( $table, $alias = '' ) {
 		$this->froms[] = new From( $table, $alias );
 
 		return $this;

--- a/src/DB/QueryBuilder/Concerns/FromClause.php
+++ b/src/DB/QueryBuilder/Concerns/FromClause.php
@@ -17,7 +17,7 @@ trait FromClause {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  string  $alias
+	 * @param  null|string  $alias
 	 *
 	 * @return $this
 	 */

--- a/src/DB/QueryBuilder/Concerns/JoinClause.php
+++ b/src/DB/QueryBuilder/Concerns/JoinClause.php
@@ -36,7 +36,7 @@ trait JoinClause {
 	 * @param  string|RawSQL  $table
 	 * @param  string  $column1
 	 * @param  string  $column2
-	 * @param  null|string  $alias
+	 * @param  string|null  $alias
 	 *
 	 * @return static
 	 */
@@ -56,7 +56,7 @@ trait JoinClause {
 	 * @param  string|RawSQL  $table
 	 * @param  string  $column1
 	 * @param  string  $column2
-	 * @param  null|string  $alias
+	 * @param  string|null  $alias
 	 *
 	 * @return static
 	 */
@@ -76,7 +76,7 @@ trait JoinClause {
 	 * @param  string|RawSQL  $table
 	 * @param  string  $column1
 	 * @param  string  $column2
-	 * @param  null|string  $alias
+	 * @param  string|null  $alias
 	 *
 	 * @return static
 	 */

--- a/src/DB/QueryBuilder/Concerns/JoinClause.php
+++ b/src/DB/QueryBuilder/Concerns/JoinClause.php
@@ -36,7 +36,7 @@ trait JoinClause {
 	 * @param  string|RawSQL  $table
 	 * @param  string  $column1
 	 * @param  string  $column2
-	 * @param  string  $alias
+	 * @param  null|string  $alias
 	 *
 	 * @return static
 	 */
@@ -56,7 +56,7 @@ trait JoinClause {
 	 * @param  string|RawSQL  $table
 	 * @param  string  $column1
 	 * @param  string  $column2
-	 * @param  string  $alias
+	 * @param  null|string  $alias
 	 *
 	 * @return static
 	 */
@@ -76,7 +76,7 @@ trait JoinClause {
 	 * @param  string|RawSQL  $table
 	 * @param  string  $column1
 	 * @param  string  $column2
-	 * @param  string  $alias
+	 * @param  null|string  $alias
 	 *
 	 * @return static
 	 */

--- a/src/DB/QueryBuilder/Concerns/JoinClause.php
+++ b/src/DB/QueryBuilder/Concerns/JoinClause.php
@@ -36,11 +36,11 @@ trait JoinClause {
 	 * @param  string|RawSQL  $table
 	 * @param  string  $column1
 	 * @param  string  $column2
-	 * @param  string|null  $alias
+	 * @param  string  $alias
 	 *
 	 * @return static
 	 */
-	public function leftJoin( $table, $column1, $column2, $alias = null ) {
+	public function leftJoin( $table, $column1, $column2, $alias = '' ) {
 		$this->join(
 			function ( JoinQueryBuilder $builder ) use ( $table, $column1, $column2, $alias ) {
 				$builder
@@ -56,11 +56,11 @@ trait JoinClause {
 	 * @param  string|RawSQL  $table
 	 * @param  string  $column1
 	 * @param  string  $column2
-	 * @param  string|null  $alias
+	 * @param  string  $alias
 	 *
 	 * @return static
 	 */
-	public function innerJoin( $table, $column1, $column2, $alias = null ) {
+	public function innerJoin( $table, $column1, $column2, $alias = '' ) {
 		$this->join(
 			function ( JoinQueryBuilder $builder ) use ( $table, $column1, $column2, $alias ) {
 				$builder
@@ -76,11 +76,11 @@ trait JoinClause {
 	 * @param  string|RawSQL  $table
 	 * @param  string  $column1
 	 * @param  string  $column2
-	 * @param  string|null  $alias
+	 * @param  string  $alias
 	 *
 	 * @return static
 	 */
-	public function rightJoin( $table, $column1, $column2, $alias = null ) {
+	public function rightJoin( $table, $column1, $column2, $alias = '' ) {
 		$this->join(
 			function ( JoinQueryBuilder $builder ) use ( $table, $column1, $column2, $alias ) {
 				$builder

--- a/src/DB/QueryBuilder/JoinQueryBuilder.php
+++ b/src/DB/QueryBuilder/JoinQueryBuilder.php
@@ -19,7 +19,7 @@ class JoinQueryBuilder {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  string  $alias
+	 * @param  null|string  $alias
 	 *
 	 * @return $this
 	 */
@@ -33,7 +33,7 @@ class JoinQueryBuilder {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  string  $alias
+	 * @param  null|string  $alias
 	 *
 	 * @return $this
 	 */
@@ -47,7 +47,7 @@ class JoinQueryBuilder {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  string  $alias
+	 * @param  null|string  $alias
 	 *
 	 * @return $this
 	 */
@@ -122,11 +122,11 @@ class JoinQueryBuilder {
 	 *
 	 * @param  string  $joinType
 	 * @param  string|RawSQL  $table
-	 * @param  string  $alias
+	 * @param  null|string  $alias
 	 *
 	 * @return $this
 	 */
-	private function join( $joinType, $table, $alias ) {
+	private function join( $joinType, $table, $alias = '' ) {
 		$this->joins[] = new Join(
 			$joinType,
 			$table,

--- a/src/DB/QueryBuilder/JoinQueryBuilder.php
+++ b/src/DB/QueryBuilder/JoinQueryBuilder.php
@@ -19,11 +19,11 @@ class JoinQueryBuilder {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  null|string  $alias
+	 * @param  string  $alias
 	 *
 	 * @return $this
 	 */
-	public function leftJoin( $table, $alias = null ) {
+	public function leftJoin( $table, $alias = '' ) {
 		return $this->join(
 			JoinType::LEFT,
 			$table,
@@ -33,11 +33,11 @@ class JoinQueryBuilder {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  null|string  $alias
+	 * @param  string  $alias
 	 *
 	 * @return $this
 	 */
-	public function rightJoin( $table, $alias = null ) {
+	public function rightJoin( $table, $alias = '' ) {
 		return $this->join(
 			JoinType::RIGHT,
 			$table,
@@ -47,11 +47,11 @@ class JoinQueryBuilder {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  null|string  $alias
+	 * @param  string  $alias
 	 *
 	 * @return $this
 	 */
-	public function innerJoin( $table, $alias = null ) {
+	public function innerJoin( $table, $alias = '' ) {
 		return $this->join(
 			JoinType::INNER,
 			$table,

--- a/src/DB/QueryBuilder/JoinQueryBuilder.php
+++ b/src/DB/QueryBuilder/JoinQueryBuilder.php
@@ -19,7 +19,7 @@ class JoinQueryBuilder {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  null|string  $alias
+	 * @param  string|null  $alias
 	 *
 	 * @return $this
 	 */
@@ -33,7 +33,7 @@ class JoinQueryBuilder {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  null|string  $alias
+	 * @param  string|null  $alias
 	 *
 	 * @return $this
 	 */
@@ -47,7 +47,7 @@ class JoinQueryBuilder {
 
 	/**
 	 * @param  string|RawSQL  $table
-	 * @param  null|string  $alias
+	 * @param  string|null  $alias
 	 *
 	 * @return $this
 	 */
@@ -122,7 +122,7 @@ class JoinQueryBuilder {
 	 *
 	 * @param  string  $joinType
 	 * @param  string|RawSQL  $table
-	 * @param  null|string  $alias
+	 * @param  string|null  $alias
 	 *
 	 * @return $this
 	 */


### PR DESCRIPTION
Passing `null` to trim() is deprecated since PHP 8.1

Ticket: https://stellarwp.atlassian.net/browse/BTRIA-2080