### PR TITLE
Add a basic upsert method

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ composer require stellarwp/db
 - [CRUD](#crud)
   - [Insert](#insert)
   - [Update](#update)
+  - [Upsert](#upsert)
   - [Delete](#delete)
   - [Get](#get)
 
@@ -845,6 +846,28 @@ DB::table('posts')
         'post_title'   => 'Post Title 2',
         'post_content' => 'Post Content 2'
     ]);
+```
+
+### Upsert
+
+The `QueryBuilder::upsert` method may be used to update an existing record or create a new record if it doesn't exist.
+
+```php
+// Would result in a new row - Oakland to San Diego for 100.
+DB::table('table_name')
+    ->upsert(
+        ['departure' => 'Oakland', 'destination' => 'San Diego', 'price' => '100'] ,
+        ['departure','destination']
+    );
+
+
+// Would update the row that was just inserted - Oakland to San Diego for 99.
+DB::table('table_name')
+    ->upsert(
+        ['departure' => 'Oakland', 'destination' => 'San Diego', 'price' => '99'] ,
+        ['departure','destination']
+    );
+
 ```
 
 ### Delete

--- a/src/DB/QueryBuilder/Concerns/CRUD.php
+++ b/src/DB/QueryBuilder/Concerns/CRUD.php
@@ -48,7 +48,22 @@ trait CRUD {
 		);
 	}
 
-	public function upsert( $data, $match = null, $format = null ) {
+	/**
+	 * @param $data
+	 * @param $match
+	 * @param $format
+	 *
+	 * @return false|int
+	 */
+	public function upsert( $data, $match = [], $format = null ) {
+		foreach( $match as $column => $value ) {
+			$this->where( $column, $value );
+		}
+		$exists = $this->get();
+
+		if ( $exists ) {
+			return $this->update( $data, $format );
+		}
 		return $this->insert( $data, $format );
 	}
 

--- a/src/DB/QueryBuilder/Concerns/CRUD.php
+++ b/src/DB/QueryBuilder/Concerns/CRUD.php
@@ -49,15 +49,19 @@ trait CRUD {
 	}
 
 	/**
-	 * @param $data
-	 * @param $match
-	 * @param $format
+	 * Upsert allows for inserting or updating a row depending on whether it already exists.
+	 *
+	 * @since 1.0.8
+	 *
+	 * @param array $data The data to insert or update.
+	 * @param array $match The columns to match on.
+	 * @param string|null $format
 	 *
 	 * @return false|int
 	 */
 	public function upsert( $data, $match = [], $format = null ) {
 		// Build the where clause(s).
-		foreach( $match as $column ) {
+		foreach ( $match as $column ) {
 			$this->where( $column, $data[$column] );
 		}
 

--- a/src/DB/QueryBuilder/Concerns/CRUD.php
+++ b/src/DB/QueryBuilder/Concerns/CRUD.php
@@ -48,6 +48,10 @@ trait CRUD {
 		);
 	}
 
+	public function upsert( $data, $match = null, $format = null ) {
+		return $this->insert( $data, $format );
+	}
+
 	/**
 	 * @since 1.0.0
 	 *

--- a/src/DB/QueryBuilder/Concerns/CRUD.php
+++ b/src/DB/QueryBuilder/Concerns/CRUD.php
@@ -62,7 +62,7 @@ trait CRUD {
 	public function upsert( $data, $match = [], $format = null ) {
 		// Build the where clause(s).
 		foreach ( $match as $column ) {
-			$this->where( $column, $data[$column] );
+			$this->where( $column, $data[ $column ] );
 		}
 
 		// If the row exists, update it.

--- a/src/DB/QueryBuilder/Concerns/CRUD.php
+++ b/src/DB/QueryBuilder/Concerns/CRUD.php
@@ -59,11 +59,11 @@ trait CRUD {
 		foreach( $match as $column => $value ) {
 			$this->where( $column, $value );
 		}
-		$exists = $this->get();
 
-		if ( $exists ) {
+		if ( $this->get() ) {
 			return $this->update( $data, $format );
 		}
+
 		return $this->insert( $data, $format );
 	}
 

--- a/src/DB/QueryBuilder/Concerns/CRUD.php
+++ b/src/DB/QueryBuilder/Concerns/CRUD.php
@@ -53,11 +53,11 @@ trait CRUD {
 	 *
 	 * @since 1.0.8
 	 *
-	 * @param array $data The data to insert or update.
+	 * @param array<string, string|int|float|bool|null> $data The data to insert or update.
 	 * @param array $match The columns to match on.
-	 * @param string|null $format
+	 * @param string|array|null $format Array of formats to be mapped to each value in $data. If string, the format will be used for all values in $data.
 	 *
-	 * @return false|int
+	 * @return false|int Number of rows updated/inserted, false on error.
 	 */
 	public function upsert( $data, $match = [], $format = null ) {
 		// Build the where clause(s).

--- a/src/DB/QueryBuilder/Concerns/CRUD.php
+++ b/src/DB/QueryBuilder/Concerns/CRUD.php
@@ -56,14 +56,17 @@ trait CRUD {
 	 * @return false|int
 	 */
 	public function upsert( $data, $match = [], $format = null ) {
-		foreach( $match as $column => $value ) {
-			$this->where( $column, $value );
+		// Build the where clause(s).
+		foreach( $match as $column ) {
+			$this->where( $column, $data[$column] );
 		}
 
+		// If the row exists, update it.
 		if ( $this->get() ) {
 			return $this->update( $data, $format );
 		}
 
+		// Otherwise, insert it.
 		return $this->insert( $data, $format );
 	}
 

--- a/tests/wpunit/QueryBuilder/CRUDTest.php
+++ b/tests/wpunit/QueryBuilder/CRUDTest.php
@@ -180,7 +180,7 @@ final class CRUDTest extends DBTestCase
 		];
 
 		$match = [
-			'post_title' => 'Query Builder CRUD test - upsert update',
+			'post_title',
 		];
 
 		DB::table('posts')->upsert( $updated_data, $match );

--- a/tests/wpunit/QueryBuilder/CRUDTest.php
+++ b/tests/wpunit/QueryBuilder/CRUDTest.php
@@ -156,4 +156,39 @@ final class CRUDTest extends DBTestCase
 		$this->assertEquals($data['post_content'], $post->post_content);
 	}
 
+	/**
+	 * Tests if upsert() updates a row in the database.
+	 *
+	 * @return void
+	 */
+	public function testUpsertShouldUpdateRowInDatabase()
+	{
+		$data = [
+			'post_title' => 'Query Builder CRUD test - upsert update',
+			'post_type' => 'crud_test',
+			'post_content' => 'Hello World from upsert!',
+		];
+
+		DB::table('posts')->insert($data);
+
+		$original_id = DB::last_insert_id();
+
+		$updated_data = [
+			'post_content' => 'Hello World from upsert! - updated',
+		];
+
+		$match = [
+			'post_title' => 'Query Builder CRUD test - upsert update',
+		];
+
+		DB::table('posts')->upsert($updated_data, $match);
+
+		$post = DB::table('posts')
+			->select('post_title', 'post_type', 'post_content')
+			->where('ID', $original_id)
+			->get();
+
+		$this->assertEquals($updated_data['post_content'], $post->post_content);
+	}
+
 }

--- a/tests/wpunit/QueryBuilder/CRUDTest.php
+++ b/tests/wpunit/QueryBuilder/CRUDTest.php
@@ -174,6 +174,8 @@ final class CRUDTest extends DBTestCase
 		$original_id = DB::last_insert_id();
 
 		$updated_data = [
+			'post_title' => 'Query Builder CRUD test - upsert update',
+			'post_type' => 'crud_test',
 			'post_content' => 'Hello World from upsert! - updated',
 		];
 
@@ -181,7 +183,7 @@ final class CRUDTest extends DBTestCase
 			'post_title' => 'Query Builder CRUD test - upsert update',
 		];
 
-		DB::table('posts')->upsert($updated_data, $match);
+		DB::table('posts')->upsert( $updated_data, $match );
 
 		$post = DB::table('posts')
 			->select('post_title', 'post_type', 'post_content')

--- a/tests/wpunit/QueryBuilder/CRUDTest.php
+++ b/tests/wpunit/QueryBuilder/CRUDTest.php
@@ -191,6 +191,27 @@ final class CRUDTest extends DBTestCase
 			->get();
 
 		$this->assertEquals($updated_data['post_content'], $post->post_content);
+
+		// Test multiple match columns
+		$further_updated_data = [
+			'post_title' => 'Query Builder CRUD test - upsert update',
+			'post_type' => 'crud_test',
+			'post_content' => 'Hello World from upsert! - updated even more!',
+		];
+
+		$match = [
+			'post_title',
+			'post_type',
+		];
+
+		DB::table('posts')->upsert( $further_updated_data, $match );
+
+		$post = DB::table('posts')
+			->select('post_title', 'post_type', 'post_content')
+			->where('ID', $original_id)
+			->get();
+
+		$this->assertEquals($further_updated_data['post_content'], $post->post_content);
 	}
 
 }

--- a/tests/wpunit/QueryBuilder/CRUDTest.php
+++ b/tests/wpunit/QueryBuilder/CRUDTest.php
@@ -129,4 +129,31 @@ final class CRUDTest extends DBTestCase
         $this->assertNull($post);
     }
 
+	/**
+	 * Tests if upsert() adds a row to the database.
+	 *
+	 * @return void
+	 */
+	public function testUpsertShouldAddRowToDatabase()
+	{
+		$data = [
+			'post_title' => 'Query Builder CRUD test',
+			'post_type' => 'crud_test',
+			'post_content' => 'Hello World!',
+		];
+
+		DB::table('posts')->upsert($data);
+
+		$id = DB::last_insert_id();
+
+		$post = DB::table('posts')
+			->select('post_title', 'post_type', 'post_content')
+			->where('ID', $id)
+			->get();
+
+		$this->assertEquals($data['post_title'], $post->post_title);
+		$this->assertEquals($data['post_type'], $post->post_type);
+		$this->assertEquals($data['post_content'], $post->post_content);
+	}
+
 }


### PR DESCRIPTION
This is a simplified implementation of #8. There wasn't any discussion in that issue about whether this is a desired feature or not, but I thought I'd give it a try as an excuse play with slic and this library.

In #8 parameter 1 suggests supporting multiple inserts in a nested array. This does not appear to be available in the CRUD trait or in this library.
The second is the columns to match against.
The third param is the columns to update on match. I've opted to omit this and update all columns when a match is found.

Usage:
```
// Would result in a new row - Oakland to San Diego for 100.
DB::table('table_name')
    ->upsert(
        ['departure' => 'Oakland', 'destination' => 'San Diego', 'price' => '100'] , 
        ['departure','destination']
    );


// Would update existing row - Oakland to San Diego for 99.
DB::table('table_name')
    ->upsert(
        ['departure' => 'Oakland', 'destination' => 'San Diego', 'price' => '99'] , 
        ['departure','destination'] 
    );

```

Test coverage has been added for:
* Adding a new row to the DB using upsert
* Upserting an existing row with 1 matching column.
* Upserting an existing row with 2 matching columns.