### PR TITLE
Add Generator API methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. This project adhere to the [Semantic Versioning](http://semver.org/) standard.
 
+## [1.0.8] TBD
+
+* Feat - Add the `DB::generate_results` and `DB::generate_col` methods to the `DB` class to fetch all results matching an unbounded query with a set of bounded queries.
+
 ## [1.0.7] 2023-10-23
 
 * Tweak - Updates around `trim()` for php 8.1 compatibility.

--- a/src/DB/DB.php
+++ b/src/DB/DB.php
@@ -2,7 +2,9 @@
 
 namespace StellarWP\DB;
 
+use Closure;
 use Exception;
+use Generator;
 use StellarWP\DB\Database\Exceptions\DatabaseQueryException;
 use StellarWP\DB\QueryBuilder\Clauses\RawSQL;
 use StellarWP\DB\QueryBuilder\QueryBuilder;
@@ -14,18 +16,18 @@ use WP_Error;
  * A static decorator for the $wpdb class and decorator function which does SQL error checking when performing queries.
  * If a SQL error occurs a DatabaseQueryException is thrown.
  *
- * @method static int|bool query(string $query)
- * @method static int|false insert(string $table, array $data, array|string|null $format = null)
- * @method static int|false delete(string $table, array $where, array|string|null $where_format = null)
- * @method static int|false update(string $table, array $data, array $where, array|string|null $format = null, array|string|null $where_format = null)
- * @method static int|false replace(string $table, array $data, array|string|null $format = null)
- * @method static null|string get_var(string|null $query = null, int $x = 0, int $y = 0)
- * @method static array|object|null|void get_row(string|null $query = null, string $output = OBJECT, int $y = 0)
- * @method static array get_col(string|null $query = null, int $x = 0)
- * @method static array|object|null get_results(string|null $query = null, string $output = OBJECT)
+ * @method static int|bool query( string $query )
+ * @method static int|false insert( string $table, array $data, array|string|null $format = null )
+ * @method static int|false delete( string $table, array $where, array|string|null $where_format = null )
+ * @method static int|false update( string $table, array $data, array $where, array|string|null $format = null, array|string|null $where_format = null )
+ * @method static int|false replace( string $table, array $data, array|string|null $format = null )
+ * @method static null|string get_var( string|null $query = null, int $x = 0, int $y = 0 )
+ * @method static array|object|null|void get_row( string|null $query = null, string $output = OBJECT, int $y = 0 )
+ * @method static array get_col( string|null $query = null, int $x = 0 )
+ * @method static array|object|null get_results( string|null $query = null, string $output = OBJECT )
  * @method static string get_charset_collate()
- * @method static string esc_like(string $text)
- * @method static string remove_placeholder_escape(string $text)
+ * @method static string esc_like( string $text )
+ * @method static string remove_placeholder_escape( string $text )
  * @method static Config config()
  */
 class DB {
@@ -61,14 +63,14 @@ class DB {
 	/**
 	 * Runs the dbDelta function and returns a WP_Error with any errors that occurred during the process
 	 *
-	 * @see dbDelta() for parameter and return details
-	 *
 	 * @since 1.0.0
 	 *
 	 * @param $delta
 	 *
 	 * @return array
 	 * @throws DatabaseQueryException
+	 * @see   dbDelta() for parameter and return details
+	 *
 	 */
 	public static function delta( $delta ) {
 		return self::runQueryWithErrorChecking(
@@ -81,14 +83,14 @@ class DB {
 	/**
 	 * A convenience method for the $wpdb->prepare method
 	 *
-	 * @see WPDB::prepare() for usage details
-	 *
 	 * @since 1.0.0
 	 *
 	 * @param string $query
-	 * @param mixed ...$args
+	 * @param mixed  ...$args
 	 *
 	 * @return false|mixed
+	 * @see   WPDB::prepare() for usage details
+	 *
 	 */
 	public static function prepare( $query, ...$args ) {
 		global $wpdb;
@@ -113,7 +115,7 @@ class DB {
 			static function () use ( $name, $arguments ) {
 				global $wpdb;
 
-				if ( in_array( $name, [ 'get_row', 'get_col', 'get_results', 'query' ], true) ) {
+				if ( in_array( $name, [ 'get_row', 'get_col', 'get_results', 'query' ], true ) ) {
 					$hook_prefix = Config::getHookPrefix();
 
 					/**
@@ -121,7 +123,7 @@ class DB {
 					 *
 					 * @since 1.0.0
 					 *
-					 * @param string $argument First argument passed to the $wpdb method.
+					 * @param string $argument    First argument passed to the $wpdb method.
 					 * @param string $hook_prefix Prefix for the hook.
 					 */
 					do_action( 'stellarwp_db_pre_query', current( $arguments ), $hook_prefix );
@@ -132,7 +134,7 @@ class DB {
 						 *
 						 * @since 1.0.0
 						 *
-						 * @param string $argument First argument passed to the $wpdb method.
+						 * @param string $argument    First argument passed to the $wpdb method.
 						 * @param string $hook_prefix Prefix for the hook.
 						 */
 						do_action( "{$hook_prefix}_stellarwp_db_pre_query", current( $arguments ), $hook_prefix );
@@ -173,7 +175,7 @@ class DB {
 	 * Create QueryBuilder instance
 	 *
 	 * @param string|RawSQL $table
-	 * @param string|null  $alias
+	 * @param string|null   $alias
 	 *
 	 * @return QueryBuilder
 	 */
@@ -249,7 +251,7 @@ class DB {
 	 * If $args are provided, we will assume that dev wants to use DB::prepare method with raw SQL
 	 *
 	 * @param string $sql
-	 * @param array ...$args
+	 * @param array  ...$args
 	 *
 	 * @return RawSQL
 	 */
@@ -271,7 +273,7 @@ class DB {
 		global $wpdb, $EZSQL_ERROR;
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-		$errorCount = is_array( $EZSQL_ERROR ) ? count( $EZSQL_ERROR ) : 0;
+		$errorCount    = is_array( $EZSQL_ERROR ) ? count( $EZSQL_ERROR ) : 0;
 		$hasShowErrors = $wpdb->hide_errors();
 
 		$output = $queryCaller();
@@ -307,7 +309,7 @@ class DB {
 		$wpError = new WP_Error();
 
 		if ( is_array( $EZSQL_ERROR ) ) {
-			for ( $index = $initialCount, $indexMax = count( $EZSQL_ERROR ); $index < $indexMax; $index++ ) {
+			for ( $index = $initialCount, $indexMax = count( $EZSQL_ERROR ); $index < $indexMax; $index ++ ) {
 				$error = $EZSQL_ERROR[ $index ];
 
 				if ( empty( $error['error_str'] ) || empty( $error['query'] ) || 0 === strpos(
@@ -322,5 +324,108 @@ class DB {
 		}
 
 		return $wpError;
+	}
+
+	/**
+	 * Get all the results from a query in batches.
+	 *
+	 * @since TBD
+	 *
+	 * @param string  $query      The SQL query.
+	 * @param int     $batch_size The number of results to return in each batch.
+	 * @param Closure $fetch      The function to fetch the results.
+	 *
+	 * @return Generator<mixed> A generator to get all the results of the query.
+	 */
+	private static function run_batched_query( string $query, int $batch_size, Closure $fetch ): Generator {
+		// Capture the end part of the main query, the one not bound with parentheses.
+		preg_match( '/([^)(]*?)$/', $query, $matches );
+
+		// Does the end part of the query contain a LIMIT? Look for `LIMIT <offset>, <limit>` or `LIMIT <limit>`.
+		$has_limit = (bool) preg_match( '/LIMIT\\s+\\d+\\s*(,\\s*\\d+)*$/i', $matches[1] );
+
+		if ( $has_limit ) {
+			yield from $fetch( $query );
+
+			return;
+		}
+
+		// Add a LIMIT template to the query.
+		$query_template = trim( $query . ' LIMIT %d, %d' );
+
+		$offset     = 0;
+		$found_rows = 0;
+		$fetched    = 0;
+		$key        = 0;
+
+		// Set up the first query, make sure ot include SQL_CALC_FOUND_ROWS.
+		$first_query = self::prepare(
+			$query_template,
+			$offset,
+			$batch_size
+		);
+
+		// Build the first query to include SQL_CALC_FOUND_ROWS if not already present.
+		$first_query = preg_replace( '/^SELECT\\s*(?!SQL_CALC_FOUND_ROWS)/i', 'SELECT SQL_CALC_FOUND_ROWS ', $first_query );
+
+		$run_query = $first_query;
+
+		do {
+			foreach ( $fetch( $run_query ) as $result ) {
+				$fetched ++;
+				yield $key => $result;
+				$key ++;
+			}
+
+			if ( $offset === 0 ) {
+				// First run.
+				$found_rows = (int) self::get_var( 'SELECT FOUND_ROWS()' );
+			}
+
+			$offset += $batch_size;
+
+			// Compile the query for the next run.
+			$run_query = self::prepare(
+				$query_template,
+				$offset,
+				$batch_size
+			);
+		} while ( $fetched < $found_rows );
+	}
+
+	/**
+	 * Get all the results from a query in batches.
+	 *
+	 * This method should be used to run an unbounded query in batches.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|null $query      The SQL query.
+	 * @param string      $output     The required return type. One of OBJECT, ARRAY_A, ARRAY_N.
+	 * @param int         $batch_size The number of results to return in each batch.
+	 *
+	 * @return Generator<array|object|null> A generator to get all the results of the query.
+	 */
+	public static function generate_results( string $query = null, string $output = OBJECT, int $batch_size = 20 ): Generator {
+		yield from self::run_batched_query( $query, $batch_size, static function ( string $run_query ) use ( $output ) {
+			return self::get_results( $run_query, $output );
+		} );
+	}
+
+	/**
+	 * Get all the values in a column from a query in batches.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|null $query      The SQL query.
+	 * @param int         $x          The column number to return.
+	 * @param int         $batch_size The number of results to return in each batch.
+	 *
+	 * @return Generator<mixed> The values of the column.
+	 */
+	public function generate_col( string $query = null, int $x = 0, int $batch_size = 50 ): Generator {
+		yield from self::run_batched_query( $query, $batch_size, static function ( string $run_query ) use ( $x ) {
+			return self::get_col( $run_query, $x );
+		} );
 	}
 }

--- a/tests/_support/Helper/DBTestCase.php
+++ b/tests/_support/Helper/DBTestCase.php
@@ -2,9 +2,10 @@
 
 namespace StellarWP\DB\Tests;
 
+use Codeception\TestCase\WPTestCase;
 use StellarWP\DB\DB;
 
-class DBTestCase extends \Codeception\Test\Unit {
+class DBTestCase extends WPTestCase {
 	protected $backupGlobals = false;
 
 	public function setUp() {

--- a/tests/wpunit/GeneratorApiTest.php
+++ b/tests/wpunit/GeneratorApiTest.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace StellarWP\DB;
+
+use Generator;
+use stdClass;
+use StellarWP\DB\Tests\DBTestCase;
+use WP_Post;
+
+class GeneratorApitest extends DBTestCase {
+	private $logged_queries = [];
+
+
+	private function startListeningToQueries(): void {
+		$this->logged_queries = [];
+
+		if ( has_filter( 'query', [ $this, 'log_query' ] ) ) {
+			return;
+		}
+
+		add_filter( 'query', [ $this, 'log_query' ] );
+	}
+
+	private function assertCountQueriesToSelectFoundRows( int $expected ): void {
+		$queries = array_filter(
+			$this->logged_queries,
+			static function ( string $query ) {
+				return false !== stripos( $query, 'SELECT FOUND_ROWS()' );
+			}
+		);
+
+		$this->assertCount(
+			$expected,
+			$queries,
+			"Expected to find $expected queries to select found rows, but found " . count( $queries )
+		);
+	}
+
+	private function assertCountQueriesToFetchResults( int $expected ) {
+		$queries = array_filter(
+			$this->logged_queries,
+			static function ( string $query ) {
+				return false === stripos( $query, 'SELECT FOUND_ROWS()' );
+			}
+		);
+
+		$this->assertCount(
+			$expected,
+			$queries,
+			"Expected to find $expected queries to fetch results, but found " . count( $queries )
+		);
+	}
+
+	public function log_query( string $query ) {
+		$this->logged_queries[] = $query;
+
+		return $query;
+	}
+
+	/**
+	 * It should fetch all elements with batched queries
+	 *
+	 * @test
+	 */
+	public function should_fetch_all_elements_with_batched_queries(): void {
+		$posts = static::factory()->post->create_many( 7 );
+		$this->startListeningToQueries();
+
+		global $wpdb;
+		$query             = DB::prepare(
+			"SELECT * FROM %i",
+			$wpdb->posts
+		);
+		$results_generator = DB::generate_results( $query, OBJECT, 3 );
+		$all_results       = iterator_to_array( $results_generator );
+
+		$this->assertInstanceOf( Generator::class, $results_generator );
+		$this->assertCount( 7, $all_results );
+		$this->assertEqualSets( $posts, array_map( static function ( stdClass $post ) {
+			return $post->ID;
+		}, $all_results ) );
+		$this->assertCountQueriesToSelectFoundRows( 1 );
+		$this->assertCountQueriesToFetchResults( 3 );
+
+		$this->startListeningToQueries();
+
+		$query         = DB::prepare(
+			"SELECT ID FROM %i",
+			$wpdb->posts
+		);
+		$ids_generator = DB::generate_col( $query, 0, 3 );
+		$all_ids       = iterator_to_array( $ids_generator );
+
+		$this->assertInstanceOf( Generator::class, $ids_generator );
+		$this->assertCount( 7, $all_ids );
+		$this->assertEqualSets( $posts, $all_ids );
+		$this->assertCountQueriesToSelectFoundRows( 1 );
+		$this->assertCountQueriesToFetchResults( 3 );
+	}
+
+	/**
+	 * It should fetch all elements with batched query when query contains sub-query
+	 *
+	 * @test
+	 */
+	public function should_fetch_all_elements_with_batched_query_when_query_contains_sub_query(): void {
+		$books  = static::factory()->post->create_many( 3, [ 'post_type' => 'book' ] );
+		$movies = static::factory()->post->create_many( 3, [ 'post_type' => 'movie' ] );
+		$posts  = static::factory()->post->create_many( 3, [ 'post_type' => 'post' ] );
+
+		global $wpdb;
+		$query = DB::prepare(
+			"SELECT * FROM %i WHERE ID NOT IN (
+				SELECT ID FROM %i WHERE post_type = 'book'
+			)",
+			$wpdb->posts,
+			$wpdb->posts
+		);
+		$this->startListeningToQueries();
+
+		$results_generator = DB::generate_results( $query, OBJECT, 2 );
+		$all_results       = iterator_to_array( $results_generator );
+
+		$this->assertInstanceOf( Generator::class, $results_generator );
+		$this->assertCount( 6, $all_results );
+		$this->assertEqualSets( array_merge( $movies, $posts ), array_map( static function ( stdClass $post ) {
+			return $post->ID;
+		}, $all_results ) );
+		$this->assertCountQueriesToSelectFoundRows( 1 );
+		$this->assertCountQueriesToFetchResults( 3 );
+
+		$query = DB::prepare(
+			"SELECT ID FROM %i WHERE ID NOT IN (
+				SELECT ID FROM %i WHERE post_type = 'book'
+			)",
+			$wpdb->posts,
+			$wpdb->posts
+		);
+		$this->startListeningToQueries();
+
+		$ids_generator = DB::generate_col( $query, 0, 2 );
+		$all_ids       = iterator_to_array( $ids_generator );
+
+		$this->assertInstanceOf( Generator::class, $ids_generator );
+		$this->assertCount( 6, $all_ids );
+		$this->assertEqualSets( array_merge( $movies, $posts ), $all_ids );
+		$this->assertCountQueriesToSelectFoundRows( 1 );
+		$this->assertCountQueriesToFetchResults( 3 );
+	}
+
+	/**
+	 * It should not alter a query that already has a LIMIT clause
+	 *
+	 * @test
+	 */
+	public function should_not_alter_a_query_that_already_has_a_limit_clause(): void {
+		$posts = static::factory()->post->create_many( 7 );
+		$this->startListeningToQueries();
+
+		global $wpdb;
+		$query             = DB::prepare(
+			"SELECT * FROM %i LIMIT 4",
+			$wpdb->posts
+		);
+		$results_generator = DB::generate_results( $query, OBJECT, 3 );
+		$all_results       = iterator_to_array( $results_generator );
+
+		$this->assertInstanceOf( Generator::class, $results_generator );
+		$this->assertCount( 4, $all_results );
+		$this->assertEqualSets( array_slice( $posts, 0, 4 ), array_map( static function ( stdClass $post ) {
+			return $post->ID;
+		}, $all_results ) );
+		$this->assertCountQueriesToSelectFoundRows( 0 );
+		$this->assertCountQueriesToFetchResults( 1 );
+
+		$this->startListeningToQueries();
+
+		$query = DB::prepare(
+			"SELECT ID FROM %i LIMIT 4",
+			$wpdb->posts
+		);
+
+		$ids_generator = DB::generate_col( $query, 0, 3 );
+		$all_ids       = iterator_to_array( $ids_generator );
+
+		$this->assertInstanceOf( Generator::class, $ids_generator );
+		$this->assertCount( 4, $all_ids );
+		$this->assertEqualSets( array_slice( $posts, 0, 4 ), $all_ids );
+		$this->assertCountQueriesToSelectFoundRows( 0 );
+		$this->assertCountQueriesToFetchResults( 1 );
+	}
+
+	/**
+	 * It should respect the output format when getting results
+	 *
+	 * @test
+	 */
+	public function should_respect_the_output_format_when_getting_results(): void {
+		$posts = static::factory()->post->create_many( 7 );
+		$this->startListeningToQueries();
+
+		global $wpdb;
+		$query             = DB::prepare(
+			"SELECT * FROM %i",
+			$wpdb->posts
+		);
+		$results_generator = DB::generate_results( $query, ARRAY_A, 3 );
+
+		$all_results = iterator_to_array( $results_generator );
+
+		$this->assertInstanceOf( Generator::class, $results_generator );
+		$this->assertCount( 7, $all_results );
+		$this->assertContainsOnly( 'array', $all_results );
+		$this->assertEqualSets( $posts, array_map( static function ( array $post ) {
+			return $post['ID'];
+		}, $all_results ) );
+		$this->assertCountQueriesToSelectFoundRows( 1 );
+
+		$this->startListeningToQueries();
+
+		$query         = DB::prepare(
+			"SELECT ID FROM %i",
+			$wpdb->posts
+		);
+		$ids_generator = DB::generate_results( $query, OBJECT, 3 );
+
+		$all_ids = iterator_to_array( $ids_generator );
+
+		$this->assertInstanceOf( Generator::class, $ids_generator );
+		$this->assertCount( 7, $all_ids );
+		$this->assertContainsOnlyInstancesOf( stdClass::class, $all_ids );
+		$this->assertEqualSets( $posts, array_map( static function ( stdClass $post ) {
+			return $post->ID;
+		}, $all_ids ) );
+		$this->assertCountQueriesToSelectFoundRows( 1 );
+
+		$this->startListeningToQueries();
+
+		$query         = DB::prepare(
+			"SELECT ID FROM %i",
+			$wpdb->posts
+		);
+		$ids_generator = DB::generate_results( $query, ARRAY_N, 3 );
+		$all_results   = iterator_to_array( $ids_generator );
+
+		$this->assertInstanceOf( Generator::class, $ids_generator );
+		$this->assertCount( 7, $all_results );
+		$this->assertContainsOnly( 'array', $all_results );
+		$this->assertEqualSets( $posts, array_map( static function ( array $post ) {
+			return $post[0];
+		}, $all_results ) );
+		$this->assertCountQueriesToSelectFoundRows( 1 );
+	}
+
+	/**
+	 * It should respect the x when getting column
+	 *
+	 * @test
+	 */
+	public function should_respect_the_x_when_getting_column(): void {
+		$posts = static::factory()->post->create_many( 7 );
+		$this->startListeningToQueries();
+
+		global $wpdb;
+		$query         = DB::prepare(
+			"SELECT post_name, post_status, post_title, ID FROM %i",
+			$wpdb->posts
+		);
+		$ids_generator = DB::generate_col( $query, 3, 3 );
+		$all_ids       = iterator_to_array( $ids_generator );
+
+		$this->assertInstanceOf( Generator::class, $ids_generator );
+		$this->assertCount( 7, $all_ids );
+		$this->assertEqualSets( $posts, $all_ids );
+		$this->assertCountQueriesToSelectFoundRows( 1 );
+	}
+
+	/**
+	 * It should correctly handle LIMIT in edge-case queries
+	 *
+	 * @test
+	 */
+	public function should_correctly_handle_limit_in_edge_case_queries(): void {
+		$limited_editions = static::factory()->post->create_many( 7, [ 'post_type' => 'limited_edition' ] );
+		$this->startListeningToQueries();
+
+		global $wpdb;
+		$query             = DB::prepare(
+			"SELECT * FROM %i limited_editition",
+			$wpdb->posts
+		);
+		$results_generator = DB::generate_results( $query, OBJECT, 3 );
+		$all_results       = iterator_to_array( $results_generator );
+
+		$this->assertInstanceOf( Generator::class, $results_generator );
+		$this->assertCount( 7, $all_results );
+		$this->assertEqualSets( $limited_editions, array_map( static function ( stdClass $post ) {
+			return $post->ID;
+		}, $all_results ) );
+		$this->assertCountQueriesToSelectFoundRows( 1 );
+		$this->assertCountQueriesToFetchResults( 3 );
+	}
+}


### PR DESCRIPTION
This PR adds the `DB::generate_results` and `DB::generate_col` methods to allow unbounded queries to run, under the hood, in a bounded manner.

The query results will be fetched in batches that will be returned by a Generator, reducing database and memory load where no alternative is possible.

Example, given a db with 100 posts, one could run the following query:

```sql
SELECT * FROM wp_posts
```

The following code will iterate over **all** posts in the database, fetching them in batches of 100 each:

```php
$all_posts = DB::generate_results( 'SELECT * FROM wp_posts', OBJECT, 100 );

foreach( $all_posts as $post ) {
    // Do something with the post ...
}
```

The same can be done for columns:

```php
$all_ids = DB::generate_col( 'SELECT ID FROM wp_posts', 0, 100 );

foreach( $all_ids as $id ) {
    // Do something with the post ID ...
}
```
