### PR TITLE
Bugfix: PHP doc types

### DIFF
--- a/src/DB/QueryBuilder/Clauses/Where.php
+++ b/src/DB/QueryBuilder/Clauses/Where.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
  * @since 1.0.0
  */
 class Where {
+
 	/**
 	 * @var string
 	 */
@@ -28,11 +29,6 @@ class Where {
 	 * @var string
 	 */
 	public $logicalOperator;
-
-	/**
-	 * @var string|null
-	 */
-	public $type;
 
 	/**
 	 * @param  string  $column

--- a/src/DB/QueryBuilder/Clauses/Where.php
+++ b/src/DB/QueryBuilder/Clauses/Where.php
@@ -36,7 +36,7 @@ class Where {
 
 	/**
 	 * @param  string  $column
-	 * @param  string  $value
+	 * @param  mixed  $value
 	 * @param  string  $comparisonOperator
 	 * @param  string|null  $logicalOperator
 	 */

--- a/src/DB/QueryBuilder/Concerns/WhereClause.php
+++ b/src/DB/QueryBuilder/Concerns/WhereClause.php
@@ -29,7 +29,7 @@ trait WhereClause {
 
 	/**
 	 * @param  string|Closure|null  $column  The Closure will receive a StellarWP\DB\QueryBuilder\WhereQueryBuilder instance
-	 * @param  string|Closure|array|null  $value  The Closure will receive a StellarWP\DB\QueryBuilder\QueryBuilder instance
+	 * @param  string|Closure|array|null|mixed  $value  The Closure will receive a StellarWP\DB\QueryBuilder\QueryBuilder instance
 	 * @param  string  $comparisonOperator
 	 * @param  string  $logicalOperator
 	 *
@@ -79,7 +79,7 @@ trait WhereClause {
 
 	/**
 	 * @param  string|Closure|null  $column  The closure will receive a StellarWP\DB\QueryBuilder\WhereQueryBuilder instance
-	 * @param  string|Closure|array|null  $value  The closure will receive a StellarWP\DB\QueryBuilder\QueryBuilder instance
+	 * @param  string|Closure|array|null|mixed  $value  The closure will receive a StellarWP\DB\QueryBuilder\QueryBuilder instance
 	 * @param  string  $comparisonOperator
 	 *
 	 * @return $this
@@ -95,7 +95,7 @@ trait WhereClause {
 
 	/**
 	 * @param  string|Closure  $column
-	 * @param  string|Closure|array|null  $value
+	 * @param  string|Closure|array|null|mixed  $value
 	 * @param  string  $comparisonOperator
 	 *
 	 * @return $this
@@ -255,7 +255,7 @@ trait WhereClause {
 
 	/**
 	 * @param  string  $column
-	 * @param  string  $value
+	 * @param  mixed  $value
 	 *
 	 * @return $this
 	 */
@@ -269,7 +269,7 @@ trait WhereClause {
 
 	/**
 	 * @param  string  $column
-	 * @param  string  $value
+	 * @param  mixed  $value
 	 *
 	 * @return $this
 	 */


### PR DESCRIPTION
### Main Changes
* PHPStan complaining about passing an integer into `where()` values.
* Removes unused variable `$type` in Where clause