### PR TITLE
Make the explicit nullable type for PHP 8.4 compatibility

### DIFF
--- a/src/DB/DB.php
+++ b/src/DB/DB.php
@@ -460,7 +460,7 @@ class DB {
 	 *
 	 * @return Generator<array|object|null> A generator to get all the results of the query.
 	 */
-	public static function generate_results( string $query = null, string $output = OBJECT, int $batch_size = 20 ): Generator {
+	public static function generate_results( ?string $query = null, string $output = OBJECT, int $batch_size = 20 ): Generator {
 		yield from self::run_batched_query( $query, $batch_size, static function ( string $run_query ) use ( $output ) {
 			return self::get_results( $run_query, $output );
 		} );
@@ -477,7 +477,7 @@ class DB {
 	 *
 	 * @return Generator<mixed> The values of the column.
 	 */
-	public function generate_col( string $query = null, int $x = 0, int $batch_size = 50 ): Generator {
+	public function generate_col( ?string $query = null, int $x = 0, int $batch_size = 50 ): Generator {
 		yield from self::run_batched_query( $query, $batch_size, static function ( string $run_query ) use ( $x ) {
 			return self::get_col( $run_query, $x );
 		} );

--- a/src/DB/Database/Exceptions/DatabaseQueryException.php
+++ b/src/DB/Database/Exceptions/DatabaseQueryException.php
@@ -33,7 +33,7 @@ class DatabaseQueryException extends \Exception {
 		array $queryErrors,
 		string $message = 'Database Query',
 		$code = 0,
-		Throwable $previous = null
+		?Throwable $previous = null
 	) {
 		$this->query = $query;
 		$this->queryErrors = $queryErrors;


### PR DESCRIPTION
I found this issue https://github.com/stellarwp/db/issues/27

And also have some deprecation messages in PHP console when i use 8.4+ version.
So I decided to make this PR.

Hope for the feedback.